### PR TITLE
Tut-image is link to next page

### DIFF
--- a/einfachjabber/apps/mainsite/templates/tutorial-navigation.html
+++ b/einfachjabber/apps/mainsite/templates/tutorial-navigation.html
@@ -1,21 +1,22 @@
 <div id="tut-navigation">
     {% if not pagedata.more %}
-    {# middle page #}
-    {% if flpage == 1 %}
-      <a class="nav-all nav-back" href="{{ url_for('tutorial', tid=tid, page=page-1) }}" title="Zurück">&lt;</a>
-      <a class="nav-all nav-next" href="{{ url_for('tutorial', tid=tid, page=page+1) }}" title="Weiter">&gt;</a>
-    {% endif %}
-    {# first page #}
-    {% if flpage == 0 %}
-      <a class="nav-all nav-back" href="{{ url_for('clientlist', osystem=osystem) }}" title="Weiter">&lt;</a>
-      <a class="nav-all nav-next" href="{{ url_for('tutorial', tid=tid, page=page+1) }}" title="Weiter">&gt;</a>
-    {% endif %}
-    {# last page #}
-    {% if flpage == 2 %}
-      <a class="nav-all nav-back" href="{{ url_for('tutorial', tid=tid, page=page-1) }}" title="Zurück">&lt;</a>
-      <a class="nav-all nav-next" href="{{ url_for('tutoriallinks', tid=tid) }}" title="Weiter">&gt;</a>
-    {% endif %}
+        {# middle page #}
+        {% if flpage == 1 %}
+          <a class="nav-all nav-back" href="{{ url_for('tutorial', tid=tid, page=page-1) }}" title="Zurück">&lt;</a>
+          <a class="nav-all nav-next" href="{{ url_for('tutorial', tid=tid, page=page+1) }}" title="Weiter">&gt;</a>
+        {% endif %}
+        {# first page #}
+        {% if flpage == 0 %}
+          <a class="nav-all nav-back" href="{{ url_for('clientlist', osystem=osystem) }}" title="Zurück zur Übersicht">&lt;</a>
+          <a class="nav-all nav-next" href="{{ url_for('tutorial', tid=tid, page=page+1) }}" title="Weiter">&gt;</a>
+        {% endif %}
+        {# last page #}
+        {% if flpage == 2 %}
+          <a class="nav-all nav-back" href="{{ url_for('tutorial', tid=tid, page=page-1) }}" title="Zurück">&lt;</a>
+          <a class="nav-all nav-next" href="{{ url_for('tutoriallinks', tid=tid) }}" title="Weiter zu den Links">&gt;</a>
+        {% endif %}
     {% else %}
     <a class="nav-all nav-back" href="{{ url_for('tutorial', tid=tid, page=page-1) }}" title="Zurück">&lt;</a>
     {% endif %}
-  </div>
+</div>
+

--- a/einfachjabber/apps/mainsite/templates/tutorial.html
+++ b/einfachjabber/apps/mainsite/templates/tutorial.html
@@ -3,15 +3,20 @@
 {% block title %}Jabber Client-Tutorial: {{ metadata.client.full }} für {{ metadata.os.full }}{% endblock %}
 {% block content %}
   <h1>{{ metadata.client.full }} {{ metadata.clientversion }} für {{ metadata.os.full }}</h1>
-  {% include "mainsite/tutorial-pagination.html"%}
-  {% include "mainsite/tutorial-navigation.html"%}
-      {% if pagedata[1] %}
-        <img id="tut-image" src="/images/{{ tid|lower + '/' + pagedata[1] }}" alt="{{ pagedata[1] }}" />
-      {% endif %}
-      <div id="caption">{{ pagedata[0]|to_mdown }}</div>
-      {% if pagedata.more %}
-      <a href="{{ url_for('mainsite.tutorial', tid=tid, page=page+1) }}">{{ pagedata.defaultlink }}</a><br />
-      <a href="{{ url_for('mainsite.tutorialmore', tid=tid, page=page+1) }}">{{ pagedata.morelink }}</a>
-      {% endif %}
-
+    {% include "mainsite/tutorial-pagination.html"%}
+    {% include "mainsite/tutorial-navigation.html"%}
+    {% if pagedata[1] %}
+        {# last page #}
+        {% if flpage == 2 %}
+            <a href="{{ url_for('tutoriallinks', tid=tid) }}" title="Weiter zu den Links"><img id="tut-image" src="/images/{{ tid|lower + '/' + pagedata[1] }}" alt="{{ pagedata[1] }}" /></a>
+        {% else %}
+            <a href="{{ url_for('tutorial', tid=tid, page=page+1) }}" title="Weiter"><img id="tut-image" src="/images/{{ tid|lower + '/' + pagedata[1] }}" alt="{{ pagedata[1] }}" /></a>
+        {% endif %}
+    {% endif %}
+    <div id="caption">{{ pagedata[0]|to_mdown }}</div>
+    {% if pagedata.more %}
+        <a href="{{ url_for('mainsite.tutorial', tid=tid, page=page+1) }}">{{ pagedata.defaultlink }}</a><br />
+        <a href="{{ url_for('mainsite.tutorialmore', tid=tid, page=page+1) }}">{{ pagedata.morelink }}</a>
+    {% endif %}
 {% endblock %}
+


### PR DESCRIPTION
I just noticed that the images shown in the tutorials is not a link to the next page, so i decided to patch this out of hand.

When browsing the code I also corrected the indentation to make it more readable and improved 2 link-titles to a more meaningful text.

I haven't tested the code, but I doubt it breaks anything.
